### PR TITLE
feat(docs): add production-grade governance layer (CLAUDE.md, CORE_RULES, ADRs, conventions, CI hooks)

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -1,0 +1,19 @@
+{
+  "extends": ["@commitlint/config-conventional"],
+  "rules": {
+    "type-enum": [
+      2,
+      "always",
+      ["feat", "fix", "docs", "refactor", "test", "chore", "perf", "ci"]
+    ],
+    "scope-enum": [
+      2,
+      "always",
+      ["agent", "api", "worker", "lambda", "web", "infra", "docs", "ci"]
+    ],
+    "subject-case": [2, "always", "lower-case"],
+    "subject-max-length": [2, "always", 100],
+    "body-max-line-length": [2, "always", 120],
+    "footer-max-line-length": [2, "always", 120]
+  }
+}

--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,48 @@
+---
+name: Bug Report
+about: Something is broken or behaving unexpectedly
+title: '[BUG] '
+labels: ['bug']
+---
+
+## Summary
+
+<!-- What is broken? What is the expected vs actual behavior? -->
+
+**Expected**:
+**Actual**:
+
+## Service
+
+<!-- Which service is exhibiting the bug? -->
+- [ ] agent/ (Go daemon)
+- [ ] api/ (Fastify)
+- [ ] worker/ (Python Volatility3)
+- [ ] lambda/ (Python dispatcher)
+- [ ] web/ (Next.js UI)
+
+## Steps to Reproduce
+
+1.
+2.
+3.
+
+## Error Output / Logs
+
+```
+<!-- Paste relevant logs here. Remove any secrets before pasting. -->
+```
+
+## Environment
+
+- Service version / git SHA:
+- OS / Platform:
+- Relevant env vars (NO secrets):
+
+## Root Cause Hypothesis
+
+<!-- If you have a theory, state it. Run /debug if stuck. -->
+
+## Fix Approach
+
+<!-- If known. Leave blank if unsure. -->

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,50 @@
+---
+name: Feature / Implementation
+about: A new feature or implementation task (linked to DAG.md)
+title: '[FEAT] '
+labels: ['feature']
+---
+
+## Summary
+
+<!-- 1-3 sentences describing what this implements and why. -->
+
+## DAG Reference
+
+<!-- Issue number from DAG.md. List dependencies. -->
+
+**DAG Issue**: #
+**Blocked by**: #
+**Blocks**: #
+
+## Service(s) Affected
+
+<!-- Check all that apply -->
+- [ ] agent/ (Go daemon)
+- [ ] api/ (Fastify)
+- [ ] worker/ (Python Volatility3)
+- [ ] lambda/ (Python dispatcher)
+- [ ] web/ (Next.js UI)
+- [ ] infra/ (docker-compose, AWS)
+- [ ] docs/
+
+## Acceptance Criteria
+
+<!-- Verifiable, testable statements. All must be met before the PR is merged. -->
+
+- [ ] Given [context], when [action], then [outcome]
+- [ ] Given [context], when [action], then [outcome]
+
+## Technical Notes
+
+<!-- Architecture constraints, ADRs to reference, known gotchas. -->
+
+- Read: `docs/prd-[service].md`
+- Read: `docs/adr/[relevant ADR]`
+- Relevant section in `ARCHITECTURE.md`:
+
+## Spec
+
+<!-- Link to spec file once created. -->
+
+**Spec**: `docs/specs/[ISSUE-NUMBER]-[feature-name].md`

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,78 @@
+## Summary
+
+<!-- 1-3 sentences describing what this PR does. -->
+
+## Related Issue
+
+Closes #[ISSUE-NUMBER]
+
+## Spec
+
+**Spec**: `docs/specs/[ISSUE-NUMBER]-[feature-name].md` (N/A for bug fixes / dependency updates)
+
+## ADR
+
+**ADR**: `docs/adr/[NNNN]-[title].md` (N/A if no architectural decision)
+
+---
+
+## Checklist
+
+### Before Submitting
+- [ ] Spec file exists and is linked above (or N/A for bug fix / chore)
+- [ ] ADR created and linked (if architectural decision made)
+- [ ] All commits follow `type(scope): description` format (scope: agent|api|worker|lambda|web|infra|docs)
+- [ ] Branch name follows `feat/[ISSUE-NUMBER]-[desc]` or `fix/[ISSUE-NUMBER]-[desc]`
+- [ ] DAG.md dependencies for this issue are all merged
+
+### Security
+- [ ] All new Fastify routes protected by `sessionAuth` or `apiKeyAuth` (no unauthenticated endpoints without approval)
+- [ ] No tokens, secrets, or API keys logged or returned in response bodies
+- [ ] Claude API key not added to env vars — SSM Parameter Store only
+- [ ] Better Auth used for all auth operations — no custom auth code
+
+### Database (if schema changed)
+- [ ] New tables/columns defined in `api/src/db/schema.ts` first
+- [ ] Migration generated with `pnpm drizzle-kit generate` and committed
+- [ ] `ON DELETE RESTRICT` on `machines.namespace_id` preserved
+- [ ] No manual creation of Better Auth tables (user, session, account, organization, member, invitation, apikey)
+
+### Worker (if worker/ or lambda/ changed)
+- [ ] Volatility3 subprocess still uses `unshare --net`
+- [ ] No network access added to the subprocess
+- [ ] ISF symbol files not pulled at runtime — bundled in image
+- [ ] `ephemeralStorageGiB` matches task definition if Dockerfile changed
+
+### Tests
+- [ ] Unit tests written for new domain functions
+- [ ] Integration/E2E tests written for new API endpoints / queue handlers
+- [ ] Test coverage not reduced
+
+### Code Quality
+- [ ] No `any` types (TypeScript), no bare `except` (Python), no `panic` (Go)
+- [ ] No hardcoded secrets or credentials
+- [ ] No `console.log` / `print()` / `fmt.Println` left in production code
+- [ ] No TODOs — GitHub issues opened for follow-up work instead
+
+### Service Changes
+- [ ] `AGENTS.md` updated if service behavior or architecture changed
+- [ ] `.env.example` updated if new environment variables added
+- [ ] `ARCHITECTURE.md` updated if domain model changed (new entity, renamed field)
+- [ ] `docker compose up` still works after changes
+
+---
+
+## Testing Instructions
+
+<!-- How should reviewers test this? Step-by-step. -->
+
+1.
+2.
+
+## Screenshots / Recordings
+
+<!-- For UI changes. Optional. -->
+
+## Notes for Reviewer
+
+<!-- Anything the reviewer should pay special attention to, known limitations, or follow-up issues. -->

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,9 @@
+#!/usr/bin/env sh
+# commit-msg hook — validates Conventional Commits format
+# Format: type(scope): description
+# Valid types: feat, fix, docs, refactor, test, chore, perf, ci
+# Valid scopes: agent, api, worker, lambda, web, infra, docs, ci
+
+. "$(dirname "$0")/_/husky.sh"
+
+npx --no -- commitlint --edit "$1"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,6 @@
+#!/usr/bin/env sh
+# pre-commit hook — runs lint and format checks on staged files
+
+. "$(dirname "$0")/_/husky.sh"
+
+npx lint-staged

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,19 @@
+#!/usr/bin/env sh
+# pre-push hook — blocks direct pushes to main/master
+# All changes must go through a Pull Request
+
+. "$(dirname "$0")/_/husky.sh"
+
+PROTECTED_BRANCHES="^(main|master)$"
+
+while read local_ref local_sha remote_ref remote_sha; do
+  remote_branch=$(echo "$remote_ref" | sed 's|refs/heads/||')
+  if echo "$remote_branch" | grep -qE "$PROTECTED_BRANCHES"; then
+    echo "✗ Direct push to '$remote_branch' is not allowed."
+    echo "  All changes must go through a Pull Request."
+    echo "  Create a feature branch and open a PR instead."
+    exit 1
+  fi
+done
+
+exit 0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,236 @@
+# CLAUDE.md — Agent Contract
+
+> This file governs how Claude Code operates in this repository.
+> It also applies to all other AI agents (Copilot, Codex, Cursor, etc.) — `AGENTS.md` is an alias to this file.
+> Read this before taking **any** action.
+
+---
+
+## Project Context
+
+Read these before every session:
+- **[ARCHITECTURE.md](ARCHITECTURE.md)** — system overview, service map, auth model, database schema, queue design, failure paths, constraints
+- **[DAG.md](DAG.md)** — 33-issue build plan with dependency graph and parallel lanes
+- **Per-service PRD** — `docs/prd-{agent,api,worker,lambda,web}.md` for the service you're working on
+
+> **Missing file check**: If `ARCHITECTURE.md` does not exist, **stop immediately** and tell the human before proceeding.
+
+---
+
+## Quick Start
+
+| Situation | Action | gstack skill |
+|---|---|---|
+| Evaluating a new idea | Think first, then use office hours | `/office-hours` |
+| Writing a plan (>2 files) | Spec Gate + Plan Gate → EnterPlanMode | `/plan-eng-review` before exiting |
+| Architectural decision | ADR Gate — create ADR first | — |
+| Pre-landing code check | Run before pushing | `/review` |
+| Creating a PR | Full PR workflow | `/ship` |
+| CI check failing | Fix root cause — never `--no-verify` | `/debug` |
+| Stuck / blocked | Diagnose root cause | `/debug` |
+| Feature added / changed / removed | See CORE_RULES Rule 15 | — |
+| Unclear requirements | `AskUserQuestion` — never assume | — |
+| Potential secret in code | Flag it, do not commit | — |
+
+---
+
+## Mandatory Pre-Flight Checks
+
+Before starting any task, you MUST:
+
+1. **Read `docs/CORE_RULES.md`** — The binding rules for this repository. No exceptions.
+2. **Find the GitHub Issue** — Task context, requirements, and acceptance criteria come from the linked issue. Cross-reference `DAG.md` to confirm dependencies are met.
+3. **Check for a spec** — Look in `docs/specs/` for a file matching the issue number. If none exists for a feature task, stop and create one before proceeding.
+4. **Check relevant ADRs** — Scan `docs/adr/` for decisions that affect the area you're working in. Key ADRs: 0001 (monorepo), 0002 (auth), 0003 (queue architecture).
+5. **Read the service AGENTS.md** — If you're modifying a specific service, read `{service}/AGENTS.md` (once it exists) before touching any code.
+6. **Check `api/src/db/schema.ts`** — If your task involves any data type (entity, enum, event), verify it's defined there. If not, define it first before writing service code.
+7. **Check gstack artifacts** — Look in `~/.gstack/projects/` for test plans, design docs, and review logs. Don't redo work that's already been saved.
+
+---
+
+## Workflow Gates
+
+### Gate 1: Spec Gate
+- **Non-trivial features require a spec.** If `docs/specs/[ISSUE-NUMBER]-*.md` does not exist, create it using `docs/specs/TEMPLATE.md` before writing any implementation code.
+- Bug fixes, dependency updates, and documentation changes are exempt.
+
+### Gate 2: Plan Gate
+- **Changes touching more than 2 files or introducing new architecture require an approved plan.**
+- Use `EnterPlanMode` to explore, design, and present your plan. Do not write production code during planning.
+- **Before exiting plan mode, run `/plan-eng-review` on your written plan.** Exit only after the plan is approved by the user.
+
+### Gate 3: ADR Gate
+- **Any architectural decision requires an ADR.** See `docs/adr/README.md` for what triggers an ADR.
+- Create the ADR in `docs/adr/[NNNN]-[title].md` before implementing the decision.
+
+---
+
+## File and Code Rules
+
+- **Prefer editing existing files over creating new ones.**
+- **Never skip git hooks.** Do not use `--no-verify` or `--no-gpg-sign`.
+- **Never add AI attribution.** Do not add `Co-Authored-By: Claude` or any AI mention in commits or PRs.
+- **Never commit to `main` directly.** All changes go through a PR on a feature branch.
+- **Never push to `main` directly.** The `.husky/pre-push` hook enforces this.
+- **Never hardcode secrets.** Use `.env` files (gitignored). Update `.env.example` with placeholder values.
+- **Claude API key lives in AWS SSM Parameter Store only.** Never in env vars, never committed.
+- **Never modify `infra/docker-compose.yml` or AWS configs without explicit human approval.**
+
+---
+
+## Task Tracking Discipline
+
+Use the built-in task system for any multi-step work:
+
+```
+TaskCreate  → when starting a complex task
+TaskUpdate  → mark in_progress before beginning, completed when done
+TaskList    → check for next task after completing one
+```
+
+Break large tasks into smaller, independently completable units. Never mark a task complete if tests are failing or implementation is partial.
+
+---
+
+## Memory Management
+
+Maintain `.claude/memory/` to preserve context across sessions:
+
+- `MEMORY.md` — high-level summary, always loaded (keep under 200 lines)
+- Topic files (e.g., `auth.md`, `database.md`) — detailed notes linked from `MEMORY.md`
+
+Write to memory when you discover:
+- Stable architectural patterns in this repo
+- Non-obvious conventions or gotchas
+- Important file paths and entry points
+- Solutions to recurring problems
+
+Do NOT write: session-specific state, incomplete conclusions, or anything that duplicates `CORE_RULES.md` or `ARCHITECTURE.md`.
+
+### gstack Artifacts
+
+```bash
+source <(~/.claude/skills/gstack/bin/gstack-slug 2>/dev/null)
+# $SLUG is now set (e.g. agarwalvivek29-memory-insight)
+```
+
+| Path | Contents |
+|---|---|
+| `~/.gstack/projects/$SLUG/*-test-plan-*.md` | QA test plans from `/plan-eng-review` |
+| `~/.gstack/projects/$SLUG/*-design-*.md` | Design docs from `/office-hours` |
+| `~/.gstack/projects/$SLUG/review-log.jsonl` | Review history |
+
+---
+
+## Capabilities and Tools
+
+### gstack Skills
+
+| Skill | When to use |
+|---|---|
+| `/office-hours` | Evaluating a new idea before any planning |
+| `/plan-eng-review` | Before exiting plan mode — reviews architecture, tests, performance |
+| `/plan-ceo-review` | For significant product direction changes |
+| `/plan-design-review` | When UI/UX changes are involved |
+| `/review` | Pre-landing code review — run before pushing |
+| `/ship` | Creating the PR — handles VERSION, CHANGELOG, branch sync |
+| `/qa` | Browser-based QA after implementation |
+| `/debug` | Systematic root-cause analysis when stuck or CI is failing |
+| `/retro` | Weekly retrospective |
+| `/document-release` | Post-ship doc updates |
+
+---
+
+## Service Modification Checklist
+
+When modifying a service (`agent/`, `api/`, `worker/`, `lambda/`, `web/`):
+
+- [ ] Read the service's `AGENTS.md` (or `ARCHITECTURE.md` + PRD if AGENTS.md doesn't exist yet)
+- [ ] Spec exists in `docs/specs/`
+- [ ] ADR created if architectural decision needed
+- [ ] Plan approved (EnterPlanMode for >2 files, `/plan-eng-review` before exiting)
+- [ ] Auth middleware applied to all new Fastify routes (`sessionAuth` or `apiKeyAuth`)
+- [ ] No custom auth logic — use Better Auth (see ADR 0002)
+- [ ] New DB tables/columns added to `api/src/db/schema.ts` first, migration generated
+- [ ] `ON DELETE RESTRICT` preserved on `machines.namespace_id` (never change to CASCADE without a migration)
+- [ ] Worker subprocess uses `unshare --net` — Volatility3 has no network access
+- [ ] Claude API key fetched from SSM at startup — never in env vars or hardcoded
+- [ ] Unit tests written for new domain functions
+- [ ] E2E/integration tests written for new API endpoints
+- [ ] `.env.example` updated if new env vars added
+- [ ] `AGENTS.md` updated if service behavior or architecture changed
+- [ ] No scaffold/example/placeholder code in the diff
+- [ ] All commits follow `type(scope): description` format
+- [ ] `/review` run before pushing
+- [ ] `/ship` used to create the PR
+
+---
+
+## Drizzle Schema Rule (Critical)
+
+Before writing any type definition in service code:
+
+1. Check if the entity/table exists in `api/src/db/schema.ts`
+2. If not → define the table there first
+3. Generate migration: `cd api && pnpm drizzle-kit generate`
+4. Commit schema + migration files together
+5. Import types from the schema in service code — never redefine them
+
+Better Auth owns: `user`, `session`, `account`, `organization`, `member`, `invitation`, `apikey` — **do not create these manually**.
+
+App tables: `namespaces`, `machines`, `jobs`, `dumps`, `analyses`, `findings`, `schedules` — all defined in `api/src/db/schema.ts`.
+
+---
+
+## Auth Rules (Critical — See ADR 0002)
+
+- **All Fastify routes** must use `sessionAuth` (session cookie) or `apiKeyAuth` (Bearer token) middleware
+- **Never build custom key hashing, session tables, or RBAC middleware**
+- **Machine tokens** (`mt_xxxx`) are Better Auth `apiKey` records with `metadata: { machine_id }`
+- **Org API key** (`sk_live_xxxx`) is used once at agent registration only — never stored on agent machines
+- **Better Auth instance** is shared: Next.js + Fastify initialize from the same `DATABASE_URL` + `BETTER_AUTH_SECRET`
+
+---
+
+## Worker Security Rules (Critical)
+
+- Volatility3 subprocess must use `unshare --net` — zero network access
+- Parent Python process retains HTTPS for: Postgres writes, Claude API, SSM fetch
+- `ephemeralStorageGiB` must match task definition: 32 (small), 64 (medium), 200 (large)
+- ISF symbol files must be bundled in the Docker image — never pulled at runtime
+- Claude API key: fetched from AWS SSM Parameter Store (`boto3`) at startup — never in env vars
+
+---
+
+## Multi-Agent Strategy
+
+| Scenario | Tool |
+|---|---|
+| N GitHub Issues in parallel | `EnterWorktree` per issue — each gets an isolated branch |
+| 1 issue, N parallel sub-tasks | gstack Teams (`TeamCreate` + `Agent` tool) |
+| Sequential work (default) | Neither needed |
+
+**For worktree work:**
+- Each worktree is isolated from `main` and every other session
+- Push your feature branch when done; open a PR via `/ship`
+- `.claude/` is shared across worktrees — memory accumulates correctly
+- Never touch another worktree's branch or `main` directly
+
+---
+
+## Behavior Boundaries
+
+Without explicit human approval, you MUST NOT:
+
+- Push to remote branches
+- Create, close, or comment on GitHub Issues or PRs
+- Modify CI/CD pipeline configurations
+- Drop or migrate databases in production
+- Change infrastructure (AWS, docker-compose services, ECS task definitions)
+- Delete files that may represent in-progress work
+- Force-push any branch
+- Modify SSM Parameter Store values
+
+When in doubt: stop, explain what you were about to do, and ask.
+
+---

--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -1,0 +1,415 @@
+# Coding Conventions
+
+Language-specific standards for this monorepo. All contributions must follow these conventions.
+Agents must read the relevant section before modifying or generating code.
+
+---
+
+## General (All Languages)
+
+- **No magic numbers** — use named constants
+- **No commented-out code** — delete dead code, use version control to recover it
+- **No TODOs in merged code** — convert to GitHub Issues before merging
+- **Descriptive names** — variable and function names must explain what they do
+- **Single responsibility** — functions do one thing; files have a clear, single purpose
+- **Error handling at the boundary** — validate at system entry points (API handlers, queue consumers); trust internal code
+- **Structured logging only** — never `console.log`, `print()`, or `fmt.Println` in production code
+
+---
+
+## TypeScript (api/, web/)
+
+### Tooling
+- **Formatter**: Prettier (config in `.prettierrc`)
+- **Linter**: ESLint with `@typescript-eslint`
+- **Runtime**: Node.js LTS
+- **Package manager**: pnpm
+
+### Rules
+- `strict: true` in `tsconfig.json` — no exceptions
+- No `any` — use `unknown` and narrow types explicitly
+- No `ts-ignore` or `ts-expect-error` without a comment explaining why
+- Use `interface` for object shapes, `type` for unions/intersections/aliases
+- Path aliases via `tsconfig.json` `paths` — no relative `../../../` chains beyond 2 levels
+- Use `zod` for runtime validation of external data (API request bodies, env vars)
+- `async/await` throughout — no raw `.then()` chains
+
+### Environment variables
+```typescript
+// Validated env module — never import process.env directly in business logic
+import { env } from '@/config/env'
+
+// Use zod for env validation at startup
+import { z } from 'zod'
+const envSchema = z.object({
+  DATABASE_URL: z.string().url(),
+  BETTER_AUTH_SECRET: z.string().min(32),
+  REDIS_URL: z.string().url(),
+  // ...
+})
+export const env = envSchema.parse(process.env)
+```
+
+### API service (api/ — Fastify)
+```
+api/src/
+├── index.ts          # entry point, server bootstrap
+├── auth.ts           # Better Auth instance initialization
+├── db/
+│   ├── schema.ts     # Drizzle schema (source of truth for all app tables)
+│   └── index.ts      # db client
+├── routes/           # Fastify route handlers
+├── middleware/       # sessionAuth, apiKeyAuth (from Better Auth)
+├── domain/           # business logic, pure functions
+└── config/
+    └── env.ts        # validated env
+```
+
+**Fastify route pattern:**
+```typescript
+// Every route applies auth middleware first
+fastify.get('/machines', { preHandler: [sessionAuth] }, async (req, reply) => {
+  // req.user, req.session, req.org available after middleware
+})
+
+// Agent routes use apiKeyAuth
+fastify.post('/jobs/:id/complete', { preHandler: [apiKeyAuth] }, async (req, reply) => {
+  // req.machineId available after middleware
+})
+```
+
+**Auth middleware (do not reimplement):**
+```typescript
+// api/src/middleware/auth.ts
+export const sessionAuth: FastifyPluginCallback = async (req, reply) => {
+  const session = await auth.api.getSession({ headers: req.headers })
+  if (!session) return reply.status(401).send({ error: 'Unauthorized' })
+  req.user = session.user
+  req.session = session.session
+}
+
+export const apiKeyAuth: FastifyPluginCallback = async (req, reply) => {
+  const token = req.headers.authorization?.replace('Bearer ', '')
+  const result = await auth.api.verifyApiKey({ key: token })
+  if (!result) return reply.status(401).send({ error: 'Unauthorized' })
+  req.machineId = result.keyMetadata?.machine_id
+  req.orgId = result.key.orgId
+}
+```
+
+**Long-poll pattern (GET /jobs/pending):**
+```typescript
+// Hangs up to 30s. Returns 200 { job_id, type } or 204 on timeout.
+// Redis pub/sub subscription; resolve with 204 on disconnect or timeout.
+// Never crash the Fastify process if Redis disconnects.
+```
+
+### Web UI (web/ — Next.js 15)
+```
+web/
+├── app/              # App Router pages
+├── lib/
+│   └── auth-client.ts  # Better Auth client (createAuthClient)
+├── components/
+└── public/
+```
+
+- Use Better Auth client for all auth operations — no custom session handling
+- Server Components by default; Client Components only when needed (interactivity)
+- No `getServerSideProps` / `getStaticProps` — use App Router conventions
+
+---
+
+## Python (worker/, lambda/)
+
+### Tooling
+- **Formatter**: ruff format
+- **Linter**: ruff
+- **Type checker**: mypy (strict mode)
+- **Dependency management**: uv + `pyproject.toml` — never pip, poetry, or conda directly
+- **Test framework**: pytest
+
+### Rules
+- Type hints required on all function signatures (enforced by mypy)
+- No bare `except:` — always catch specific exceptions
+- Use `pydantic` for data models and config validation
+- Use `structlog` for structured logging — no `print()`
+- Docstrings only on public APIs and non-obvious logic
+
+### Project layout (worker/)
+```
+worker/
+├── src/
+│   └── worker/
+│       ├── __init__.py
+│       ├── main.py          # ECS Fargate entrypoint
+│       ├── analysis.py      # Volatility3 subprocess orchestration
+│       ├── findings.py      # finding classification + Claude summarization
+│       ├── storage.py       # S3 download, Postgres writes
+│       └── config.py        # pydantic settings
+├── tests/
+│   └── fixtures/            # small .lime samples for testing
+├── pyproject.toml
+└── Dockerfile
+```
+
+### Project layout (lambda/)
+```
+lambda/
+├── src/
+│   └── dispatcher/
+│       ├── __init__.py
+│       ├── handler.py       # SQS event handler
+│       └── config.py        # pydantic settings
+├── tests/
+├── pyproject.toml
+└── Dockerfile
+```
+
+### Worker subprocess rules (CRITICAL)
+```python
+import subprocess
+
+# ALWAYS use unshare --net for the Volatility3 subprocess
+result = subprocess.run(
+    ["unshare", "--net", "python3", "-m", "volatility3", ...],
+    capture_output=True,
+    timeout=300,
+)
+# Parent process retains network access.
+# Subprocess has ZERO network access. This is non-negotiable.
+```
+
+### SSM for secrets
+```python
+import boto3
+
+def get_claude_api_key() -> str:
+    """Fetch Claude API key from SSM at startup. Cache the result."""
+    ssm = boto3.client('ssm', region_name=settings.aws_region)
+    response = ssm.get_parameter(
+        Name=f'/memory-insight/{settings.env}/claude-api-key',
+        WithDecryption=True
+    )
+    return response['Parameter']['Value']
+# Never read Claude API key from env vars.
+```
+
+### Environment variables
+```python
+from pydantic_settings import BaseSettings
+
+class Settings(BaseSettings):
+    database_url: str
+    aws_region: str = "us-east-1"
+    s3_bucket: str
+    env: str = "dev"
+    # Claude API key is NOT here — comes from SSM at runtime
+
+    class Config:
+        env_file = ".env"
+
+settings = Settings()
+```
+
+### Failure handling
+```python
+# Worker: no matching ISF → write FAILED analysis record and exit (no retry)
+# Lambda: SQS publish fail → raise exception (SQS will retry via visibility timeout)
+# Always write structured error records to Postgres before exiting
+```
+
+---
+
+## Go (agent/)
+
+### Tooling
+- **Formatter**: gofmt (automatic)
+- **Linter**: golangci-lint
+- **Dependency management**: Go modules (`go.mod`)
+- **Test framework**: standard `testing` + testify
+
+### Rules
+- Follow the [Standard Go Project Layout](https://github.com/golang-standards/project-layout)
+- Error wrapping: `fmt.Errorf("context: %w", err)` — always add context
+- No `panic` in service code — return errors
+- Use `slog` (stdlib) for structured logging
+- Use `context.Context` as first parameter for all I/O operations
+- Interfaces defined at the consumer side, not the implementation side
+- Use table-driven tests
+
+### Project layout
+```
+agent/
+├── cmd/
+│   └── agent/
+│       └── main.go          # entry point, config loading
+├── internal/
+│   ├── api/                 # HTTP client for platform API
+│   │   ├── client.go        # API client (machine token auth)
+│   │   └── longpoll.go      # GET /jobs/pending long-poll loop
+│   ├── dump/                # AVML invocation, file handling
+│   ├── upload/              # S3 upload with retry
+│   └── config/
+│       └── config.go        # config loading from file + env
+├── pkg/                     # exported utilities if needed
+├── go.mod
+└── Dockerfile
+```
+
+### Machine token authentication
+```go
+// All API calls after registration use machine token
+type Client struct {
+    baseURL     string
+    machineToken string // mt_xxxx — from config file after registration
+    httpClient  *http.Client
+}
+
+func (c *Client) do(ctx context.Context, req *http.Request) (*http.Response, error) {
+    req.Header.Set("Authorization", "Bearer "+c.machineToken)
+    return c.httpClient.Do(req.WithContext(ctx))
+}
+```
+
+### Long-poll pattern
+```go
+// Retry immediately on 204 (timeout). Back off only on errors.
+func (c *Client) PollForJob(ctx context.Context) (*Job, error) {
+    for {
+        job, err := c.getNextJob(ctx)
+        if err != nil {
+            // log, back off, retry
+            continue
+        }
+        if job == nil {
+            // 204 — re-poll immediately
+            continue
+        }
+        return job, nil
+    }
+}
+```
+
+### Upload retry pattern
+```go
+// Retry 3× with exponential backoff: 5s, 25s, 125s
+// After 3 failures, call POST /jobs/:id/fail — do not silently discard
+var backoffs = []time.Duration{5 * time.Second, 25 * time.Second, 125 * time.Second}
+
+func uploadWithRetry(ctx context.Context, ...) error {
+    for i, delay := range backoffs {
+        err := upload(ctx, ...)
+        if err == nil {
+            return nil
+        }
+        if i < len(backoffs)-1 {
+            time.Sleep(delay)
+        }
+    }
+    return fmt.Errorf("upload failed after %d retries", len(backoffs))
+}
+```
+
+### Failure modes
+```go
+// AVML_FAILED / PERMISSION_DENIED → no retry, call /jobs/:id/fail immediately
+// UPLOAD_FAILED → retry 3× with backoff, then /jobs/:id/fail
+// Registration failure → exit with error (not retry)
+```
+
+---
+
+## Database (Drizzle / PostgreSQL)
+
+### Schema conventions
+```typescript
+// api/src/db/schema.ts
+import { pgTable, text, timestamp, integer } from 'drizzle-orm/pg-core'
+
+// String IDs for Better Auth compatibility (not UUID)
+export const machines = pgTable('machines', {
+  id: text('id').primaryKey().$defaultFn(() => createId()),
+  namespaceId: text('namespace_id')
+    .notNull()
+    .references(() => namespaces.id, { onDelete: 'restrict' }), // NEVER change to cascade
+  // ...
+  createdAt: timestamp('created_at').notNull().defaultNow(),
+  updatedAt: timestamp('updated_at').notNull().defaultNow(),
+})
+```
+
+- Primary keys: `text` with `cuid2` or `nanoid` (not serial/uuid) — matches Better Auth's ID format
+- Timestamps: always `timestamp with time zone` (`timestamptz`)
+- Foreign keys to Better Auth tables: `text` (Better Auth uses string IDs)
+- `ON DELETE RESTRICT` on `machines.namespace_id` — sacred, never CASCADE without migration
+
+### Migration workflow
+```bash
+# After changing schema.ts
+cd api && pnpm drizzle-kit generate  # generates migration SQL
+pnpm drizzle-kit migrate             # applies in dev
+# Commit both schema.ts changes AND generated migration files
+```
+
+---
+
+## Queue Architecture
+
+Do not mix queue types. Each has exactly one purpose.
+
+| Queue | Purpose | When to publish |
+|---|---|---|
+| Redis pub/sub | Wake long-poll connections | `PUBLISH machine:{id}:jobs {job_id}` — after creating a job record |
+| BullMQ | Repeating scheduled jobs | Creates `jobs` record, then publishes to Redis |
+| SQS | Trigger Fargate analysis | Published in `POST /jobs/:id/complete` handler |
+
+BullMQ and SQS paths are completely independent. A job going to SQS does not go through BullMQ.
+
+---
+
+## API Design
+
+- RESTful resource naming: `GET /machines`, `POST /machines`, `GET /machines/:id`
+- Consistent error format: `{ error: string, code?: string }`
+- Status codes: 200 (ok), 201 (created), 204 (no content / long-poll timeout), 400 (bad request), 401 (unauthorized), 403 (forbidden), 404 (not found), 500 (server error)
+- Pagination: cursor-based for lists (`?cursor=&limit=`)
+- All request bodies validated with Zod schemas before processing
+
+---
+
+## Docker
+
+### Multi-stage builds (required)
+```dockerfile
+# Development stage
+FROM node:22-alpine AS dev
+WORKDIR /app
+COPY package.json pnpm-lock.yaml ./
+RUN corepack enable && pnpm install
+COPY . .
+CMD ["pnpm", "dev"]
+
+# Production stage
+FROM node:22-alpine AS prod
+WORKDIR /app
+COPY --from=dev /app/dist ./dist
+COPY --from=dev /app/node_modules ./node_modules
+CMD ["node", "dist/index.js"]
+```
+
+### Agent binary (Go — static build)
+```dockerfile
+FROM golang:1.22-alpine AS builder
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux go build -o agent ./cmd/agent
+
+FROM scratch
+COPY --from=builder /app/agent /agent
+ENTRYPOINT ["/agent"]
+```
+
+The agent distribution artifact is a static binary — no Docker required on user machines.

--- a/docs/CORE_RULES.md
+++ b/docs/CORE_RULES.md
@@ -1,0 +1,273 @@
+# Core Repository Rules
+
+> **This document is law.** It applies equally to every contributor — human or AI agent.
+> No exception is valid unless it is itself captured in an ADR.
+
+---
+
+## 1. Spec-First Development
+
+**No feature code may be written without a corresponding spec file.**
+
+- Every feature, enhancement, or significant refactor requires a spec at `docs/specs/[ISSUE-NUMBER]-[feature-name].md`
+- Use `docs/specs/TEMPLATE.md` as the starting point
+- The spec must exist and be linked in the GitHub Issue **before** any implementation begins
+- Agents must verify the spec exists before starting any non-trivial coding task
+- Cross-reference `DAG.md` to confirm issue dependencies are resolved before starting
+
+Exceptions: bug fixes, typo corrections, dependency updates, and documentation-only changes.
+
+---
+
+## 2. Architecture Decision Records (ADRs)
+
+**Any decision affecting more than one service, the data layer, or infrastructure requires an ADR.**
+
+- ADRs live in `docs/adr/[NNNN]-[short-title].md`
+- Use `docs/adr/README.md` to find the next sequential number
+- ADRs are append-only — once accepted, they are never deleted, only superseded
+
+Triggers for an ADR:
+- Choosing a new database, queue, or caching layer
+- Changing API protocol
+- Adding a new shared package or cross-service dependency
+- Significant infra change (new AWS service, new docker-compose service)
+- Changing authentication/authorization strategy
+- Any decision that future contributors will ask "why did we do it this way?"
+
+Current ADRs to read before any architectural work:
+- `docs/adr/0001-monorepo-structure.md` — service layout and isolation
+- `docs/adr/0002-auth-architecture.md` — Better Auth, machine tokens, session sharing
+- `docs/adr/0003-queue-architecture.md` — Redis pub/sub vs BullMQ vs SQS separation
+
+---
+
+## 3. Plan-Before-Code
+
+**Non-trivial work requires an approved plan before implementation.**
+
+- **Agents**: Use `EnterPlanMode` for any task touching more than 2 files or introducing new architecture. Exit only when the plan is documented and approved.
+- **Humans**: Write a brief implementation plan as a comment on the GitHub Issue.
+- A "plan" must include: what files change, why, and what the rollback strategy is.
+- Agents must **not** write production code during the planning phase.
+
+---
+
+## 4. Conventional Commits
+
+**All commits must follow the Conventional Commits specification. No AI authorship attribution.**
+
+Format: `<type>(<scope>): <description>`
+
+Allowed types:
+- `feat` — new feature
+- `fix` — bug fix
+- `docs` — documentation only
+- `refactor` — code change that neither fixes a bug nor adds a feature
+- `test` — adding or correcting tests
+- `chore` — build process, dependency updates, tooling
+- `perf` — performance improvement
+- `ci` — CI/CD changes
+
+Scope is the service name (e.g., `feat(api): add machine registration endpoint`). Valid scopes: `agent`, `api`, `worker`, `lambda`, `web`, `infra`, `docs`.
+
+Hooks must **never** be skipped (`--no-verify` is forbidden unless explicitly approved in an ADR).
+
+**No AI attribution in commits or PRs:**
+- Never add `Co-Authored-By: Claude` or any AI model as a co-author
+- Never mention Claude, Anthropic, or any AI tool in PR titles, PR bodies, or commit messages
+
+---
+
+## 5. No Direct Commits to Main
+
+**Main is a protected branch. All changes arrive via Pull Request.**
+
+- PRs require at least one approval
+- All CI checks must pass before merge
+- Squash merges are preferred to keep history clean
+- Branch naming: `feat/[ISSUE-NUMBER]-[short-description]`, `fix/[ISSUE-NUMBER]-[short-description]`
+
+---
+
+## 6. Service Isolation
+
+**Each service is a self-contained unit.**
+
+Services: `agent/` (Go), `api/` (TypeScript/Fastify), `worker/` (Python), `lambda/` (Python), `web/` (TypeScript/Next.js)
+
+- Every service has its own `Dockerfile`, `.env.example`, and `AGENTS.md`
+- Services communicate only via well-defined interfaces: HTTP (agent→api), SQS (api→lambda→worker), Redis pub/sub (api→agent long-poll)
+- Shared code: none currently. If needed, create `packages/` with explicit versioning — never copy-paste between services
+
+---
+
+## 7. Docker-First Local Development
+
+**All services and infrastructure run via `docker-compose`.**
+
+- Every service must have a working `Dockerfile` with multi-stage build (dev + prod targets)
+- `infra/docker-compose.yml` is the single source of truth for local infra (Postgres, Redis)
+- Environment variables via `.env` files (gitignored); `.env.example` is always committed
+- No service should require manual steps beyond `docker compose up` for local infra
+
+---
+
+## 8. Test Coverage
+
+**PRs must not reduce test coverage below the established baseline.**
+
+Test frameworks by service:
+- `agent/` (Go): `go test ./...` + testify. Table-driven tests.
+- `api/` (TypeScript): Vitest + supertest. Route integration tests.
+- `worker/` (Python): pytest. Fixture with a real small `.lime` sample.
+- `lambda/` (Python): pytest. Mock SQS events.
+- `web/` (TypeScript): Playwright for the critical user path (register → trigger job → view finding).
+
+Unit tests live alongside code. Integration tests in `tests/` at the service root. CI enforces coverage gate.
+
+---
+
+## 9. Secret Hygiene
+
+**Secrets and credentials are never committed to the repository.**
+
+- `.env` files are always gitignored
+- `.env.example` is committed with placeholder (non-functional) values
+- Never hardcode API keys, passwords, or tokens in source code
+- CI secrets managed through GitHub Actions secrets
+- **Claude API key**: AWS SSM Parameter Store only (`/memory-insight/{env}/claude-api-key`). Never in env vars.
+- **AWS credentials**: IAM role (Fargate task role, Lambda execution role). Never hardcoded.
+- If a secret is accidentally committed: revoke it immediately, rotate it, then remove from git history
+
+---
+
+## 10. Auth Middleware (Better Auth — Mandatory)
+
+**Every Fastify API endpoint must be protected by Better Auth middleware.**
+
+Two middleware functions — use the right one per credential type:
+
+| Credential | Middleware | Used by |
+|---|---|---|
+| Session cookie | `sessionAuth` | Web UI → API calls |
+| Bearer `mt_xxxx` | `apiKeyAuth` | Agent daemon (machine token) |
+| Bearer `sk_live_xxxx` | `apiKeyAuth` | Agent registration only |
+
+Rules:
+- Middleware must be the **first** in the chain (before logging, before rate limiting)
+- On auth failure → `401 Unauthorized`
+- Never build custom key hashing, session tables, or RBAC middleware — Better Auth handles it
+- **Exempt paths** (explicit allowlist, not unprotected by default):
+  - `GET /health`
+  - `GET /metrics`
+  - Better Auth's own handler routes (`/api/auth/*`)
+
+**Machine token rule**: The org API key (`sk_live_xxxx`) is used **once** at registration (`POST /machines/register`). After that, all agent calls use machine token (`mt_xxxx`). Never store the org API key on agent machines.
+
+---
+
+## 11. Agent Operating Discipline
+
+**Agents must follow additional rules beyond those for humans.**
+
+- Read `AGENTS.md` in every service being modified before writing any code
+- Consult `docs/specs/` and `docs/adr/` before proposing solutions
+- Never modify infrastructure (docker-compose, AWS configs, ECS task definitions) without explicit human approval
+- Always prefer editing existing files over creating new ones
+- Maintain memory files (`.claude/memory/`) to preserve context across sessions
+- If a task is unclear, stop and ask — do not make assumptions that affect architecture
+- Document any new tool dependency in the service's `AGENTS.md`
+
+---
+
+## 12. Drizzle Schema-First (Database Layer)
+
+**All database entities are defined in `api/src/db/schema.ts` before any service code references them.**
+
+Better Auth owns (do not touch):
+- `user`, `session`, `account`, `organization`, `member`, `invitation`, `apikey`
+
+App tables (all in `api/src/db/schema.ts`):
+- `namespaces`, `machines`, `jobs`, `dumps`, `analyses`, `findings`, `schedules`
+
+Process for new tables or columns:
+1. Define in `api/src/db/schema.ts`
+2. Run `cd api && pnpm drizzle-kit generate` to create the migration
+3. Commit schema + migration files together before writing service code
+4. Import types from schema — never redefine them in service code
+
+**`ON DELETE RESTRICT` on `machines.namespace_id` is sacred** — never change to CASCADE without a migration that handles machine cleanup and explicit human approval.
+
+---
+
+## 13. Worker Network Isolation (Security — Non-Negotiable)
+
+**The Volatility3 subprocess must have zero network access.**
+
+- Use `unshare --net` on the subprocess that runs Volatility3 plugins
+- The **parent Python process** retains HTTPS for: Postgres writes, Claude API, SSM
+- ISF symbol files must be **bundled** in the Docker image — never pulled at runtime
+- `ephemeralStorageGiB` must match the task definition: 32 (small), 64 (medium), 200 (large)
+- Never remove or loosen this isolation — the worker processes potentially hostile memory dumps
+
+---
+
+## 14. No Example or Placeholder Data in Production Code
+
+**Scaffolded example content must be removed before any code ships.**
+
+Must be removed:
+- Sample model instances left by generators
+- Demo or scaffold routes (`GET /example`, `GET /hello`)
+- Scaffold comments: `# TODO: replace with your logic`
+- Hardcoded test credentials or placeholder tokens in source files
+
+Allowed to stay:
+- `.env.example` placeholder values (required by Rule 9)
+- `tests/fixtures/` files used exclusively by automated tests
+
+Agents: scan the full diff before pushing. Fix placeholder content in the same branch.
+
+---
+
+## 15. Feature Change Protocol
+
+**Any time a feature is added, changed, or removed, execute this protocol.**
+
+### Step 1 — Update the Drizzle schema
+- Identify every table in `api/src/db/schema.ts` affected by the change
+- Apply changes; run `cd api && pnpm drizzle-kit generate`
+- Commit schema + migration files before any service code is written
+
+### Step 2 — Update open GitHub issues
+- For each open issue whose acceptance criteria or technical notes are now stale, edit the issue body
+- Pay attention to: field renames, new required fields, changed status lifecycles
+
+### Step 3 — Create follow-up issues for affected modules
+- If the change impacts a service with no open issue tracking the required update, create one
+
+### Step 4 — Update ARCHITECTURE.md
+- If the change affects the core domain model (new entity, renamed field, changed lifecycle), update `ARCHITECTURE.md` in the same commit as the schema change
+
+---
+
+## Checklist: Before Opening a PR
+
+- [ ] Spec file exists in `docs/specs/` and is linked in the issue
+- [ ] ADR created if an architectural decision was made
+- [ ] All commits follow `type(scope): description` format
+- [ ] `AGENTS.md` updated if service behavior or architecture changed
+- [ ] New tables/columns defined in `api/src/db/schema.ts` with migration generated
+- [ ] Unit tests written for new domain logic
+- [ ] Integration tests written for new API endpoints / queue handlers
+- [ ] Coverage not reduced
+- [ ] `.env.example` updated if new env vars were added
+- [ ] No secrets committed (especially Claude API key, AWS keys)
+- [ ] No scaffold/example/placeholder code remaining in the diff
+- [ ] No AI attribution in any commit message or PR body
+- [ ] Auth middleware applied to all new Fastify routes
+- [ ] Worker subprocess still uses `unshare --net` if modified
+- [ ] `docker compose up` still works
+- [ ] `/review` run — pre-landing code review passed
+- [ ] `/ship` used to create the PR

--- a/docs/adr/0001-monorepo-structure.md
+++ b/docs/adr/0001-monorepo-structure.md
@@ -1,0 +1,50 @@
+# 0001 Monorepo with Per-Service Isolation
+
+**Date**: 2026-03-29
+**Status**: Accepted
+**Deciders**: Vivek Agarwal
+**Issue**: N/A (established during architecture design)
+
+## Context
+
+Memory Insight is a multi-service system spanning five distinct runtimes:
+- Go daemon (agent) — distributed as a static binary to customer machines
+- TypeScript/Fastify API — platform backend on Fly.io
+- Python Volatility3 worker — long-running analysis on AWS Fargate
+- Python Lambda dispatcher — SQS event routing
+- TypeScript/Next.js web UI — customer-facing UI on Fly.io
+
+Each service has a radically different runtime, dependency set, deployment target, and security boundary. The Go agent is open-source and distributed as a curl install. The worker processes potentially hostile memory dumps and must be network-isolated.
+
+The question was: single repository or separate repositories?
+
+## Decision
+
+We will use a **monorepo** with per-service isolation: one repository, services in top-level directories (`agent/`, `api/`, `worker/`, `lambda/`, `web/`), each a fully self-contained unit with its own `Dockerfile`, `.env.example`, and `AGENTS.md`.
+
+Services communicate **only via well-defined interfaces**: HTTP (agent→api), SQS (api→lambda→worker), Redis pub/sub (api→agent long-poll). No shared in-process state. No shared runtime dependencies.
+
+## Consequences
+
+### Positive
+- Single place for cross-cutting changes (auth protocol, queue contracts, schema)
+- Atomic commits across service boundaries when a feature spans multiple services
+- Easier onboarding: one repo to clone, one place to understand the system
+- DAG.md and docs/ are co-located with implementation
+
+### Negative
+- CI must isolate per-service builds (a Python worker change shouldn't trigger Go agent CI)
+- Package manager tooling (pnpm workspaces) doesn't naturally span Go and Python services
+- More disciplined about keeping services truly isolated (no "just import from ../api/")
+
+### Neutral
+- Each service is still independently deployable
+- The open-source agent lives in `agent/` — a separate public repo can mirror it if needed
+
+## Alternatives Considered
+
+### Option A: Separate repositories per service
+Rejected: atomic cross-service commits become impossible. Auth protocol changes, queue contract changes, and schema changes all span services. Coordinating across 5 repos is significant overhead for a team of one.
+
+### Option B: Shared runtime monorepo (TypeScript-only)
+Rejected: the Go agent and Python worker are non-negotiable runtime choices. The agent must be a static Go binary (no Node.js on customer machines). The worker uses Volatility3 which is Python-native.

--- a/docs/adr/0002-auth-architecture.md
+++ b/docs/adr/0002-auth-architecture.md
@@ -1,0 +1,59 @@
+# 0002 Better Auth as Unified Auth Layer
+
+**Date**: 2026-03-29
+**Status**: Accepted
+**Deciders**: Vivek Agarwal
+**Issue**: N/A (established during architecture design)
+
+## Context
+
+The platform needs:
+- Email/password sign-up and sign-in
+- GitHub OAuth
+- Organization creation, invitations, and membership management
+- Role-based access control (admin/write/read)
+- API key generation and validation for the agent daemon
+- A machine-token mechanism for per-machine identity (distinct from org API keys)
+
+The agent daemon authenticates with the API on behalf of a specific machine. The org API key is used once at registration; subsequent calls use a machine-scoped token stored locally.
+
+## Decision
+
+We will use **Better Auth** as the single auth layer for all services.
+
+Better Auth runs as a shared instance initialized with the same `DATABASE_URL` and `BETTER_AUTH_SECRET` in both Next.js (web/) and Fastify (api/). No session bridging. No shared-secret JWT. No custom key table.
+
+**Plugins enabled:**
+- `emailPassword` — email/password sign-up and sign-in
+- `socialProvider("github")` — GitHub OAuth
+- `organization` — org creation, invitations, membership, role assignment
+- `apiKey` — key generation (SHA-256 stored), validation, per-key rate limiting, expiry
+- `access` — RBAC mapping org roles to permissions
+
+**Machine token convention**: Machine tokens (`mt_xxxx`) are Better Auth `apiKey` records with `metadata: { machine_id }`. The org API key (`sk_live_xxxx`) is used **once** at `POST /machines/register` and never stored on agent machines.
+
+## Consequences
+
+### Positive
+- Zero custom auth code: no key hashing, no session bridging, no RBAC middleware
+- Better Auth owns `user`, `session`, `account`, `organization`, `member`, `invitation`, `apikey` tables — no manual management
+- Machine token revocation is a standard Better Auth API key operation
+- Org management UI routes are handled by Better Auth's built-in handlers
+
+### Negative
+- Tight coupling to Better Auth's data model and upgrade path
+- Both Next.js and Fastify must be initialized with the same env vars (operationally simple, but a misconfiguration causes auth failures across both services)
+
+### Neutral
+- Better Auth is initialized in both services — this is by design, not a bug
+
+## Alternatives Considered
+
+### Option A: Custom JWT auth with shared secret
+Rejected: requires building and maintaining key hashing, rotation, session management, org membership. Significant implementation surface and security risk.
+
+### Option B: Auth0 / Clerk / Okta
+Rejected: vendor lock-in, cost at scale, and the org/RBAC model is product-critical — we need direct database control for machine token queries and audit logging.
+
+### Option C: NextAuth.js (Fastify gets JWT tokens from Next.js)
+Rejected: requires session bridging between Next.js and Fastify. Better Auth's shared-instance model eliminates this complexity entirely.

--- a/docs/adr/0003-queue-architecture.md
+++ b/docs/adr/0003-queue-architecture.md
@@ -1,0 +1,57 @@
+# 0003 Queue Architecture: Redis pub/sub + BullMQ + SQS Separation
+
+**Date**: 2026-03-29
+**Status**: Accepted
+**Deciders**: Vivek Agarwal
+**Issue**: N/A (established during architecture design)
+
+## Context
+
+The platform has three distinct async coordination needs:
+
+1. **Agent wakeup**: The agent daemon long-polls `GET /jobs/pending`. When a new job is created, the API must wake the specific agent holding the pending HTTP connection. This is pure pub/sub — no persistence needed, just a signal.
+
+2. **Scheduled scans**: Users configure recurring scan schedules (e.g., "every 6 hours"). This requires a durable, repeating job scheduler with a backing store.
+
+3. **Fargate dispatch**: When an agent completes a memory dump upload, the API must trigger a Volatility3 analysis container on AWS Fargate. This involves ECS task launching and requires durable, at-least-once delivery with retries.
+
+## Decision
+
+We will use **three separate queue mechanisms**, each serving exactly one purpose:
+
+| Queue | Purpose | Implementation |
+|---|---|---|
+| Redis pub/sub | Wake long-poll connections | `PUBLISH machine:{id}:jobs {job_id}` |
+| BullMQ | Repeating scheduled jobs | Creates `jobs` record, publishes to Redis |
+| SQS | Trigger Fargate via Lambda | Published in `POST /jobs/:id/complete` handler |
+
+**The BullMQ and SQS paths are completely independent.** A scheduled job creates a `jobs` record and publishes to Redis to wake the agent. The SQS path is only triggered when the agent calls `POST /jobs/:id/complete` after uploading the dump.
+
+## Consequences
+
+### Positive
+- Each mechanism is optimized for its specific use case
+- Redis pub/sub is low-latency for agent wakeup — no polling delay
+- BullMQ provides repeating job semantics with Redis persistence (survives API restarts)
+- SQS provides durable at-least-once delivery for Fargate dispatch with visibility timeout retries
+- Clear separation prevents accidental coupling between scheduled jobs and analysis dispatch
+
+### Negative
+- Three queue systems to operate and monitor
+- Redis is a shared dependency for both pub/sub and BullMQ
+- More complex local development setup (Redis + SQS local emulation)
+
+### Neutral
+- SQS triggers Lambda which starts Fargate — this is the standard AWS serverless dispatch pattern
+- Lambda acts as a thin dispatcher only — no analysis logic
+
+## Alternatives Considered
+
+### Option A: BullMQ for everything
+Rejected: BullMQ doesn't naturally bridge to Fargate dispatch. Using it for agent wakeup adds unnecessary persistence and polling overhead for what is fundamentally a fire-and-forget pub/sub signal.
+
+### Option B: SQS for everything
+Rejected: SQS for agent long-poll wakeup would require the agent to poll SQS directly, adding AWS credentials to every agent machine and significant complexity. Redis pub/sub is far simpler for this use case.
+
+### Option C: Polling instead of long-poll
+Rejected: polling intervals create latency between job creation and agent pickup. Long-poll with pub/sub wakeup gives near-instant job delivery without the API hammering from repeated short-interval polls.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,108 @@
+# Architecture Decision Records (ADRs)
+
+ADRs capture significant architectural decisions made in this project, along with the context and consequences of each decision.
+
+---
+
+## What is an ADR?
+
+An ADR is a short document that records:
+- **The context**: What problem were we solving? What constraints existed?
+- **The decision**: What did we choose to do?
+- **The consequences**: What are the trade-offs? What becomes easier or harder?
+
+ADRs are written **before** implementing the decision, not after.
+
+---
+
+## When to Write an ADR
+
+Write an ADR when making a decision that:
+- Affects more than one service
+- Changes or establishes a data layer (database choice, schema strategy)
+- Changes infrastructure (new AWS service, changing queue broker)
+- Changes API protocol or communication pattern between services
+- Adds a new shared package or cross-service dependency
+- Changes authentication/authorization strategy
+- Is something a future contributor would ask "why did we do it this way?"
+
+**Exempt**: Implementation details within a single service that don't affect others.
+
+---
+
+## ADR Lifecycle
+
+```
+Proposed → Accepted → Deprecated → Superseded
+              ↓
+           (in use)
+```
+
+- **Proposed**: Written, under review
+- **Accepted**: Approved and in effect
+- **Deprecated**: No longer recommended but still technically in use
+- **Superseded**: Replaced by a newer ADR (link to the superseding ADR)
+
+ADRs are **never deleted**. They are a historical record.
+
+---
+
+## How to Write an ADR
+
+1. Find the next sequential number: look at the highest number in this directory
+2. Copy the template format below
+3. Name it: `[NNNN]-[short-kebab-case-title].md`
+4. Fill in the sections
+5. Set status to `Proposed`
+6. Submit as part of the PR that implements the decision
+7. Update status to `Accepted` when the PR is merged
+
+---
+
+## Index
+
+| # | Title | Status | Date |
+|---|---|---|---|
+| [0001](./0001-monorepo-structure.md) | Monorepo with per-service isolation | Accepted | 2026-03-29 |
+| [0002](./0002-auth-architecture.md) | Better Auth as unified auth layer | Accepted | 2026-03-29 |
+| [0003](./0003-queue-architecture.md) | Redis pub/sub + BullMQ + SQS separation | Accepted | 2026-03-29 |
+
+---
+
+## Template
+
+```markdown
+# [NNNN] [Title]
+
+**Date**: YYYY-MM-DD
+**Status**: Proposed | Accepted | Deprecated | Superseded by [NNNN]
+**Deciders**: [names or roles]
+**Issue**: [GitHub issue link]
+
+## Context
+
+[Describe the problem, constraints, and forces at play]
+
+## Decision
+
+[State the decision clearly. "We will..."]
+
+## Consequences
+
+### Positive
+- [benefit 1]
+
+### Negative
+- [drawback 1]
+
+### Neutral
+- [trade-off 1]
+
+## Alternatives Considered
+
+### Option A: [Name]
+[Brief description and why it was rejected]
+
+### Option B: [Name]
+[Brief description and why it was rejected]
+```

--- a/docs/specs/TEMPLATE.md
+++ b/docs/specs/TEMPLATE.md
@@ -1,0 +1,171 @@
+# Spec: [Feature Name]
+
+> Copy this file to `docs/specs/[ISSUE-NUMBER]-[feature-name].md` and fill it in.
+> The spec must be completed and linked in the GitHub Issue before implementation begins.
+
+**Issue**: #[ISSUE-NUMBER]
+**Status**: Draft | Review | Approved | Implemented
+**Author**: [name]
+**Date**: YYYY-MM-DD
+**Services Affected**: [agent | api | worker | lambda | web — list all]
+
+---
+
+## Summary
+
+[1-3 sentences describing what this feature does and why it exists.]
+
+---
+
+## Background and Motivation
+
+[Why are we building this? What problem does it solve? What happens if we don't build it?
+Include any relevant context from ARCHITECTURE.md or the relevant PRD.]
+
+---
+
+## Scope
+
+### In Scope
+- [Specific thing 1 that will be built]
+- [Specific thing 2]
+
+### Out of Scope
+- [Thing that might seem related but is NOT part of this feature]
+- [Explicitly list deferred work to prevent scope creep]
+
+---
+
+## Acceptance Criteria
+
+> Each criterion must be verifiable. Write them as testable statements.
+
+- [ ] Given [context], when [action], then [expected outcome]
+- [ ] Given [context], when [action], then [expected outcome]
+- [ ] [Edge case handled]
+- [ ] [Error case handled]
+
+---
+
+## Technical Design
+
+### Architecture Overview
+[High-level description of the approach. Include a diagram if helpful (ASCII or Mermaid).]
+
+```
+[Optional: ASCII diagram of data flow or component interaction]
+```
+
+### API Changes (api/)
+
+#### New Endpoints
+```
+POST /v1/[resource]
+Auth: sessionAuth | apiKeyAuth
+Request: { ... }
+Response: { ... }
+```
+
+#### Modified Endpoints
+[List any changes to existing endpoints]
+
+### Database Changes (api/src/db/schema.ts)
+
+#### New Tables
+```typescript
+export const [tableName] = pgTable('[table_name]', {
+  id: text('id').primaryKey().$defaultFn(() => createId()),
+  // ...
+  createdAt: timestamp('created_at').notNull().defaultNow(),
+})
+```
+
+#### Modified Tables
+[Show schema diff — what columns are added/changed/removed]
+
+### Queue Changes
+
+| Queue | Change | Payload |
+|---|---|---|
+| Redis pub/sub | [new channel?] | `{ job_id }` |
+| BullMQ | [new job type?] | `{ ... }` |
+| SQS | [new message type?] | `{ ... }` |
+
+### Drizzle Migration
+```bash
+cd api && pnpm drizzle-kit generate  # generates migration
+# Migration file: api/drizzle/[timestamp]_[description].sql
+```
+
+---
+
+## Security Considerations
+
+- [ ] Auth middleware applied to all new routes (which: `sessionAuth` | `apiKeyAuth`)
+- [ ] No tokens/secrets logged or returned in response bodies
+- [ ] Worker subprocess isolation maintained if worker is affected
+- [ ] Claude API key still fetched from SSM (not env vars) if worker is affected
+- [ ] Rate limiting needed?
+- [ ] Input validation with Zod on all request bodies
+
+---
+
+## Observability
+
+- **Logs**: What should be logged? At what level? Which service?
+- **Metrics**: Any new metrics to track?
+- **Alerts**: Should any alert be created for failure conditions?
+
+---
+
+## Testing Plan
+
+> Run `/plan-eng-review` before implementation begins. It generates a QA test plan.
+
+**gstack test plan**: `~/.gstack/projects/{slug}/{user}-{branch}-test-plan-{date}.md`
+
+### Unit Tests
+- [ ] [Function/module that needs unit tests]
+- [ ] [Error case coverage]
+
+### Integration Tests
+- [ ] [API endpoint integration test]
+- [ ] [Queue consumer test]
+
+### E2E Tests (if UI affected)
+- [ ] [Playwright flow covering the critical path]
+
+---
+
+## Migration / Rollout Plan
+
+- **Database migrations**: [yes/no — if yes, is it backward compatible?]
+- **Breaking changes**: [yes/no — if yes, describe backward compatibility strategy]
+- **Agent version impact**: [does this require a new agent binary? min version?]
+- **Rollback plan**: How to revert if something goes wrong
+
+---
+
+## Dependencies on DAG
+
+> Check DAG.md to confirm all blocking issues are resolved before starting.
+
+- Blocked by issues: #[numbers]
+- Blocks issues: #[numbers]
+
+---
+
+## Open Questions
+
+| Question | Owner | Status |
+|---|---|---|
+| [Question about approach X] | [name] | Open |
+
+---
+
+## References
+
+- Related ADR: [link if architectural decision was needed]
+- Related PRD: `docs/prd-[service].md`
+- Related issues: #[number]
+- Architecture section: [section name in ARCHITECTURE.md]

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "memory-insight",
+  "private": true,
+  "scripts": {
+    "prepare": "husky"
+  },
+  "devDependencies": {
+    "@commitlint/cli": "^19.0.0",
+    "@commitlint/config-conventional": "^19.0.0",
+    "husky": "^9.0.0",
+    "lint-staged": "^15.0.0"
+  },
+  "lint-staged": {
+    "api/**/*.{ts,tsx}": ["eslint --fix", "prettier --write"],
+    "web/**/*.{ts,tsx}": ["eslint --fix", "prettier --write"],
+    "worker/**/*.py": ["ruff check --fix", "ruff format"],
+    "lambda/**/*.py": ["ruff check --fix", "ruff format"],
+    "agent/**/*.go": ["gofmt -w"]
+  }
+}


### PR DESCRIPTION
## Summary

Layers template governance onto the existing architecture docs without touching any application code. All five critical security/architectural constraints of Memory Insight are now enforced as binding rules, PR checklist items, and documented architectural decisions.

**Agent contract**
- `CLAUDE.md` — full operating contract adapted for memory-insight. Project-live mode (no bootstrap check). Covers workflow gates (spec, plan, ADR), Drizzle schema rule, Better Auth rules, worker \`unshare --net\` isolation, gstack skills table, and behavior boundaries.

**Binding rules**
- `docs/CORE_RULES.md` — 15 rules adapted for this stack. Key changes from template: Drizzle schema-first replaces Protobuf, Better Auth mandatory (Rule 10), worker network isolation as a named rule (Rule 13), commit scopes locked to the 5 services.

**Code conventions**
- `docs/CONVENTIONS.md` — TypeScript (Fastify patterns, Better Auth middleware, long-poll), Python (worker subprocess isolation, SSM secret fetching, pydantic settings), Go (machine token client, retry backoff). Rust dropped. Drizzle schema conventions and queue separation rules included.

**Architecture Decision Records**
- `docs/adr/0001` — monorepo with per-service isolation
- `docs/adr/0002` — Better Auth as unified auth layer (why not JWT/Auth0/NextAuth)
- `docs/adr/0003` — Redis pub/sub + BullMQ + SQS separation (each queue serves one purpose)

Pre-written from decisions already documented in `ARCHITECTURE.md` — captures the *why* for future contributors and AI agents.

**Spec template**
- `docs/specs/TEMPLATE.md` — adapted for memory-insight: DAG dependency tracking, Drizzle migration steps, worker security checklist, Better Auth middleware field

**Commit discipline + CI**
- `.commitlintrc.json` — scope-enum locked to \`agent|api|worker|lambda|web|infra|docs|ci\`
- `.husky/commit-msg` — validates conventional commits
- `.husky/pre-commit` — lint-staged per language (eslint, ruff, gofmt)
- `.husky/pre-push` — blocks direct pushes to main
- `package.json` — root-level, lint-staged config spanning all 5 services

**GitHub templates**
- `.github/PULL_REQUEST_TEMPLATE.md` — checklist covers: Better Auth middleware, Drizzle migration, worker \`unshare --net\`, SSM key rule, DAG dependency check
- `.github/ISSUE_TEMPLATE/feature.md` — DAG-aware (blocks/blocked-by fields)
- `.github/ISSUE_TEMPLATE/bug.md` — service-scoped

## Test Coverage

Docs/governance-only diff. No application code changed. No test coverage audit applicable.

## Pre-Landing Review

No application code in diff — structural review not applicable.

## Plan Completion

No plan file detected.

## Verification Results

No dev server running — verification skipped (docs-only change).

## TODOS

No TODO items completed in this PR.

## Test plan
- [x] All files created and committed cleanly (4 bisectable commits)
- [x] Husky hooks are executable
- [x] No application code touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)